### PR TITLE
Update golang to 1.9.2 and protobuf v3.5.1.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,11 @@
-FROM golang:1.6
+FROM golang:1.9.2
 
 MAINTAINER Shaun Crampton <shaun@tigera.io>
 
 ADD . /src
 WORKDIR /src
 
-# We want v3.0.0 but the tag for v3.0.0 has broken download links.  Pin to
-# master for now :-(
-ENV PROTOBUF_TAG master
+ENV PROTOBUF_TAG v3.5.1
 
 RUN ./build.sh
 


### PR DESCRIPTION
Update amd64 builds to golang 1.9.2 and protobuf v3.5.1.